### PR TITLE
v1.5.1

### DIFF
--- a/app/admin/cycles/[id]/cycle-dashboard.tsx
+++ b/app/admin/cycles/[id]/cycle-dashboard.tsx
@@ -103,6 +103,7 @@ export function CycleDashboard({
             applications={applications}
             getApplicationDetails={getApplicationDetails}
             settings={defaultSettings}
+            readOnly={!cycle.isActive}
           />
         </TabsContent>
 
@@ -110,6 +111,7 @@ export function CycleDashboard({
           <NominationsManager
             nominations={nominations}
             settings={defaultSettings}
+            readOnly={!cycle.isActive}
           />
         </TabsContent>
 

--- a/components/AdminDashboard.tsx
+++ b/components/AdminDashboard.tsx
@@ -43,6 +43,7 @@ interface AdminDashboardProps {
   applications: ApplicationWithCount[];
   getApplicationDetails: (id: string) => Promise<ApplicationWithNominations | null>;
   settings: Settings;
+  readOnly?: boolean;
 }
 
 function getNominationBadgeColor(count: number, requiredNominations: number): "success" | "warning" | "info" | "default" {
@@ -52,7 +53,7 @@ function getNominationBadgeColor(count: number, requiredNominations: number): "s
   return "default";                   // Gray for 0-1
 }
 
-export default function AdminDashboard({ applications, getApplicationDetails, settings }: AdminDashboardProps) {
+export default function AdminDashboard({ applications, getApplicationDetails, settings, readOnly = false }: AdminDashboardProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedApplicant, setSelectedApplicant] = useState<ApplicationWithCount | null>(null);
   const [applicantDetails, setApplicantDetails] = useState<ApplicationWithNominations | null>(null);
@@ -417,25 +418,29 @@ export default function AdminDashboard({ applications, getApplicationDetails, se
                                       <Download className="h-4 w-4 mr-2" />
                                       View PDF
                                     </Button>
-                                    <Button
-                                      variant="destructive"
-                                      size="sm"
-                                      onClick={handleRemovePdf}
-                                      disabled={isRemovingPdf}
-                                    >
-                                      <Trash2 className="h-4 w-4 mr-2" />
-                                      {isRemovingPdf ? 'Removing...' : 'Remove PDF'}
-                                    </Button>
+                                    {!readOnly && (
+                                      <Button
+                                        variant="destructive"
+                                        size="sm"
+                                        onClick={handleRemovePdf}
+                                        disabled={isRemovingPdf}
+                                      >
+                                        <Trash2 className="h-4 w-4 mr-2" />
+                                        {isRemovingPdf ? 'Removing...' : 'Remove PDF'}
+                                      </Button>
+                                    )}
                                   </div>
                                 </div>
                               </AlertDescription>
                             </Alert>
                             
-                            <div className="bg-muted p-4 rounded-lg">
-                              <p className="text-sm text-muted-foreground">
-                                To reject this paper nomination, click "Remove PDF" above. The nominee will then be able to collect online nominations or upload a new paper form.
-                              </p>
-                            </div>
+                            {!readOnly && (
+                              <div className="bg-muted p-4 rounded-lg">
+                                <p className="text-sm text-muted-foreground">
+                                  To reject this paper nomination, click "Remove PDF" above. The nominee will then be able to collect online nominations or upload a new paper form.
+                                </p>
+                              </div>
+                            )}
                           </div>
                         </div>
                       </>

--- a/components/NominationsManager.tsx
+++ b/components/NominationsManager.tsx
@@ -36,6 +36,7 @@ type NominationWithCommunity = Nomination & {
 interface NominationsManagerProps {
   nominations: NominationWithCommunity[];
   settings: Settings;
+  readOnly?: boolean;
 }
 
 function getStatusBadge(status: string) {
@@ -61,7 +62,7 @@ function getConstituencyBadge(nom: NominationWithCommunity) {
   return <Badge variant="outline" className="text-xs border-gray-400 dark:border-gray-500">{nom.college}</Badge>;
 }
 
-export default function NominationsManager({ nominations: initialNominations, settings }: NominationsManagerProps) {
+export default function NominationsManager({ nominations: initialNominations, settings, readOnly = false }: NominationsManagerProps) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const isInitialMount = useRef(false);
@@ -405,7 +406,7 @@ export default function NominationsManager({ nominations: initialNominations, se
           </SelectContent>
         </Select>
 
-        {selectedIds.size > 0 && (
+        {!readOnly && selectedIds.size > 0 && (
           <div className="flex gap-2">
             <Button 
               onClick={handleBulkApprove}
@@ -438,40 +439,44 @@ export default function NominationsManager({ nominations: initialNominations, se
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="w-12">
-                    <Checkbox
-                      checked={allSelected}
-                      onCheckedChange={handleSelectAll}
-                      aria-label="Select all"
-                      className={someSelected ? "data-[state=checked]:bg-primary" : ""}
-                    />
-                  </TableHead>
+                  {!readOnly && (
+                    <TableHead className="w-12">
+                      <Checkbox
+                        checked={allSelected}
+                        onCheckedChange={handleSelectAll}
+                        aria-label="Select all"
+                        className={someSelected ? "data-[state=checked]:bg-primary" : ""}
+                      />
+                    </TableHead>
+                  )}
                   <TableHead>Nominee</TableHead>
                   <TableHead>Nominator</TableHead>
                   <TableHead>Constituency</TableHead>
                   <TableHead>Major(s)</TableHead>
                   <TableHead>Submitted</TableHead>
                   <TableHead>Status</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
+                  {!readOnly && <TableHead className="text-right">Actions</TableHead>}
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filteredNominations.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={8} className="text-center text-muted-foreground py-8">
+                    <TableCell colSpan={readOnly ? 7 : 8} className="text-center text-muted-foreground py-8">
                       No nominations found
                     </TableCell>
                   </TableRow>
                 ) : (
                   filteredNominations.map((nom) => (
                     <TableRow key={nom.id}>
-                      <TableCell>
-                        <Checkbox
-                          checked={selectedIds.has(nom.id)}
-                          onCheckedChange={(checked) => handleSelectOne(nom.id, checked as boolean)}
-                          aria-label={`Select ${nom.nominee}`}
-                        />
-                      </TableCell>
+                      {!readOnly && (
+                        <TableCell>
+                          <Checkbox
+                            checked={selectedIds.has(nom.id)}
+                            onCheckedChange={(checked) => handleSelectOne(nom.id, checked as boolean)}
+                            aria-label={`Select ${nom.nominee}`}
+                          />
+                        </TableCell>
+                      )}
                       <TableCell>
                         <div className="font-medium">{nom.nominee}</div>
                       </TableCell>
@@ -489,34 +494,36 @@ export default function NominationsManager({ nominations: initialNominations, se
                         {new Date(nom.createdAt).toLocaleDateString()}
                       </TableCell>
                       <TableCell>{getStatusBadge(nom.status)}</TableCell>
-                      <TableCell className="text-right">
-                        <div className="flex justify-end gap-2">
-                          {nom.status !== 'APPROVED' && (
-                            <Button
-                              size="sm"
-                              onClick={() => handleApprove(nom.id)}
-                              disabled={isProcessing}
-                              variant="outline"
-                              className="border-success text-success hover:bg-success-muted"
-                            >
-                              <CheckCircle className="h-3 w-3 mr-1" />
-                              Approve
-                            </Button>
-                          )}
-                          {nom.status !== 'REJECTED' && (
-                            <Button
-                              size="sm"
-                              onClick={() => handleReject(nom.id)}
-                              disabled={isProcessing}
-                              variant="outline"
-                              className="border-error text-error hover:bg-error-muted"
-                            >
-                              <XCircle className="h-3 w-3 mr-1" />
-                              Reject
-                            </Button>
-                          )}
-                        </div>
-                      </TableCell>
+                      {!readOnly && (
+                        <TableCell className="text-right">
+                          <div className="flex justify-end gap-2">
+                            {nom.status !== 'APPROVED' && (
+                              <Button
+                                size="sm"
+                                onClick={() => handleApprove(nom.id)}
+                                disabled={isProcessing}
+                                variant="outline"
+                                className="border-success text-success hover:bg-success-muted"
+                              >
+                                <CheckCircle className="h-3 w-3 mr-1" />
+                                Approve
+                              </Button>
+                            )}
+                            {nom.status !== 'REJECTED' && (
+                              <Button
+                                size="sm"
+                                onClick={() => handleReject(nom.id)}
+                                disabled={isProcessing}
+                                variant="outline"
+                                className="border-error text-error hover:bg-error-muted"
+                              >
+                                <XCircle className="h-3 w-3 mr-1" />
+                                Reject
+                              </Button>
+                            )}
+                          </div>
+                        </TableCell>
+                      )}
                     </TableRow>
                   ))
                 )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nomination-system/source",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nomination-system/source",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomination-system/source",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This pull request introduces a new `readOnly` mode to both the `AdminDashboard` and `NominationsManager` components, ensuring that when a cycle is inactive, users cannot perform actions that modify data. This helps prevent unintended changes during inactive cycles and improves the integrity of the nomination process. The `readOnly` prop is propagated from the cycle dashboard based on the cycle's active status, and UI elements for destructive or modifying actions are hidden or disabled accordingly.

**Read-only mode for inactive cycles:**

- Added a `readOnly` prop to `AdminDashboard` and `NominationsManager`, defaulting to `false`, and passed it from `CycleDashboard` based on `cycle.isActive`. When `readOnly` is `true`, UI elements for destructive or modifying actions (such as removing PDFs, rejecting nominations, or bulk approving) are hidden or disabled. [[1]](diffhunk://#diff-815c8ac03403f8f4e92ad5648f1c43032eb5c3736658f15c60f2b0c38b951d56R46) [[2]](diffhunk://#diff-815c8ac03403f8f4e92ad5648f1c43032eb5c3736658f15c60f2b0c38b951d56L55-R56) [[3]](diffhunk://#diff-316b7767165a9676d6f6f16d32eee5644c4bb2ca91167111ce8c8120cfbc43b9R39) [[4]](diffhunk://#diff-316b7767165a9676d6f6f16d32eee5644c4bb2ca91167111ce8c8120cfbc43b9L64-R65) [app/admin/cycles/[id]/cycle-dashboard.tsxR106-R114](diffhunk://#diff-3db31b714b1d0d0eecdb8c6bdabb1f374145c8aa6dc2e27fc7bea2be1f150ac0R106-R114))

- Updated the rendering logic in both components to conditionally display or hide action buttons, checkboxes, and instructional text based on the `readOnly` state, preventing users from making changes in inactive cycles. [[1]](diffhunk://#diff-815c8ac03403f8f4e92ad5648f1c43032eb5c3736658f15c60f2b0c38b951d56R421) [[2]](diffhunk://#diff-815c8ac03403f8f4e92ad5648f1c43032eb5c3736658f15c60f2b0c38b951d56R431-R443) [[3]](diffhunk://#diff-316b7767165a9676d6f6f16d32eee5644c4bb2ca91167111ce8c8120cfbc43b9L408-R409) [[4]](diffhunk://#diff-316b7767165a9676d6f6f16d32eee5644c4bb2ca91167111ce8c8120cfbc43b9R442) [[5]](diffhunk://#diff-316b7767165a9676d6f6f16d32eee5644c4bb2ca91167111ce8c8120cfbc43b9R451-R479) [[6]](diffhunk://#diff-316b7767165a9676d6f6f16d32eee5644c4bb2ca91167111ce8c8120cfbc43b9R497) [[7]](diffhunk://#diff-316b7767165a9676d6f6f16d32eee5644c4bb2ca91167111ce8c8120cfbc43b9R526)

**Version bump:**

- Incremented the package version from `1.5.0` to `1.5.1` in `package.json` to reflect the new read-only functionality.