### PR TITLE
#54 Filter nominees by active cycle on nomination form

### DIFF
--- a/lib/actions/nominations.ts
+++ b/lib/actions/nominations.ts
@@ -41,9 +41,10 @@ export async function createNomination(data: NominationData) {
       throw new Error('You cannot nominate yourself for Senator');
     }
 
-    // Validate: Nominee must exist and get their constituency info
+    // Validate: Nominee must exist in the active cycle and get their constituency info
+    const activeCycle = await getActiveCycle();
     const nomineeApp = await db.application.findFirst({
-      where: { fullName: data.nominee },
+      where: { fullName: data.nominee, cycleId: activeCycle.id },
       select: { 
         constituency: true,
         communityConstituencyId: true,
@@ -86,8 +87,6 @@ export async function createNomination(data: NominationData) {
     }
 
     // Create nomination with PENDING status
-    const activeCycle = await getActiveCycle();
-
     await db.nomination.create({
       data: {
         fullName: data.fullName,

--- a/lib/data/applications.ts
+++ b/lib/data/applications.ts
@@ -176,12 +176,15 @@ export async function getApplicationsWithNominationCounts() {
 }
 
 export async function getNominationFormData() {
-  // Get all nominees (applications)
+  const activeCycle = await getActiveCycle();
+
+  // Get nominees from the active cycle only
   const allNominees = await db.application.findMany({
-    select: { 
-      fullName: true, 
+    where: { cycleId: activeCycle.id },
+    select: {
+      fullName: true,
       email: true,
-      nominationFormPdfUrl: true 
+      nominationFormPdfUrl: true
     },
   });
 
@@ -191,6 +194,7 @@ export async function getNominationFormData() {
     .map(({ fullName, email }) => ({ fullName, email }));
 
   const constituencies = await db.application.findMany({
+    where: { cycleId: activeCycle.id },
     select: { constituency: true },
     distinct: ['constituency'],
   });


### PR DESCRIPTION
## Summary
- Scopes the nominees list in `getNominationFormData()` to `cycleId: activeCycle.id` so only current-cycle applicants appear on the nomination form
- Applies the same `cycleId` filter to the constituencies query in the same function
- Moves `getActiveCycle()` before nominee validation in `createNomination()` and scopes the lookup to the active cycle, preventing cross-cycle nominee validation

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)